### PR TITLE
Updated README.md to match the actual implementation of ioninc the command line interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Install libraries
 Create new app and build for android / ios
 -----------------
 
-    ionic create hello-world
+    ionic start hello-world
     cd hello-world
     cordova platform add android
     cordova platform add ios


### PR DESCRIPTION
Fixed the example in the readme. The ionic command line interface accepts 'start' instead of 'create'. This is documented in the help message, but appears to be outdated in the readme. If it is outdatd in the CLI help message, then sorry and don't bother with my change.
